### PR TITLE
Bug fixes 11 march

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,10 +18,21 @@ class App extends Component {
         <HashRouter>
           <Switch>
             <Route exact path='/soft-skills' component={SoftSkillsPage} />
-            <Route exact path='/courses/:course_type/:page_token/:category?/:category_id?' component={CoursesPage} />
+            <Route exact path='/soft-skills/:category_id/:page_token/'
+              render={props => <CoursesPage courseType='soft-skills' {...props} />}
+              />
+            <Route exact path='/technical/knowledge-base/domains/:category_id/:page_token/'
+              render={props => <CoursesPage courseType='domains' {...props} />}
+              />
+            <Route exact path='/technical/knowledge-base/languages/:category_id/:page_token/'
+              render={props => <CoursesPage courseType='languages' {...props} />}
+              />
+            <Route exact path='/technical/misc/:page_token/'
+              render={props => <CoursesPage courseType='random' {...props} />}
+              />
             <Route exact path='/technical/knowledge-base' component={KnowledgeBase} />
             <Route exact path='/technical/knowledge-base/domains' component={DomainPage} />
-              <Route exact path='/technical/knowledge-base/languages' component={LanguagePage} />
+            <Route exact path='/technical/knowledge-base/languages' component={LanguagePage} />
             <Route exact path='/technical' component={Technical} />
             <Route exact path='/signin' component={Signin} />
             <Route exact path='/' component={Home} />

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import SoftSkillsPage from './scenes/soft-skills-page';
 import NotFoundPage from './scenes/not-found-page';
 import ClassroomPage from './scenes/classroom-page';
 import KnowledgeBase from './scenes/knowledge-base';
+import { RANDOM, DOMAINS, LANGUAGES, SOFT_SKILLS } from './common-services/course_types';
 
 class App extends Component {
   render() {
@@ -19,16 +20,16 @@ class App extends Component {
           <Switch>
             <Route exact path='/soft-skills' component={SoftSkillsPage} />
             <Route exact path='/soft-skills/:category_id/:page_token?/'
-              render={props => <CoursesPage courseType='soft-skills' {...props} />}
+              render={props => <CoursesPage courseType={SOFT_SKILLS} {...props} />}
               />
             <Route exact path='/technical/knowledge-base/domains/:category_id/:page_token?/'
-              render={props => <CoursesPage courseType='domains' {...props} />}
+              render={props => <CoursesPage courseType={DOMAINS} {...props} />}
               />
             <Route exact path='/technical/knowledge-base/languages/:category_id/:page_token?/'
-              render={props => <CoursesPage courseType='languages' {...props} />}
+              render={props => <CoursesPage courseType={LANGUAGES} {...props} />}
               />
             <Route exact path='/technical/misc/:page_token?/'
-              render={props => <CoursesPage courseType='random' {...props} />}
+              render={props => <CoursesPage courseType={RANDOM} {...props} />}
               />
             <Route exact path='/technical/knowledge-base' component={KnowledgeBase} />
             <Route exact path='/technical/knowledge-base/domains' component={DomainPage} />

--- a/src/App.js
+++ b/src/App.js
@@ -18,16 +18,16 @@ class App extends Component {
         <HashRouter>
           <Switch>
             <Route exact path='/soft-skills' component={SoftSkillsPage} />
-            <Route exact path='/soft-skills/:category_id/:page_token/'
+            <Route exact path='/soft-skills/:category_id/:page_token?/'
               render={props => <CoursesPage courseType='soft-skills' {...props} />}
               />
-            <Route exact path='/technical/knowledge-base/domains/:category_id/:page_token/'
+            <Route exact path='/technical/knowledge-base/domains/:category_id/:page_token?/'
               render={props => <CoursesPage courseType='domains' {...props} />}
               />
-            <Route exact path='/technical/knowledge-base/languages/:category_id/:page_token/'
+            <Route exact path='/technical/knowledge-base/languages/:category_id/:page_token?/'
               render={props => <CoursesPage courseType='languages' {...props} />}
               />
-            <Route exact path='/technical/misc/:page_token/'
+            <Route exact path='/technical/misc/:page_token?/'
               render={props => <CoursesPage courseType='random' {...props} />}
               />
             <Route exact path='/technical/knowledge-base' component={KnowledgeBase} />

--- a/src/App.js
+++ b/src/App.js
@@ -19,16 +19,16 @@ class App extends Component {
         <HashRouter>
           <Switch>
             <Route exact path='/soft-skills' component={SoftSkillsPage} />
-            <Route exact path='/soft-skills/:category_id/:page_token?/'
+            <Route exact path='/soft-skills/:category_id/'
               render={props => <CoursesPage courseType={SOFT_SKILLS} {...props} />}
               />
-            <Route exact path='/technical/knowledge-base/domains/:category_id/:page_token?/'
+            <Route exact path='/technical/knowledge-base/domains/:category_id/'
               render={props => <CoursesPage courseType={DOMAINS} {...props} />}
               />
-            <Route exact path='/technical/knowledge-base/languages/:category_id/:page_token?/'
+            <Route exact path='/technical/knowledge-base/languages/:category_id/'
               render={props => <CoursesPage courseType={LANGUAGES} {...props} />}
               />
-            <Route exact path='/technical/misc/:page_token?/'
+            <Route exact path='/technical/misc/'
               render={props => <CoursesPage courseType={RANDOM} {...props} />}
               />
             <Route exact path='/technical/knowledge-base' component={KnowledgeBase} />

--- a/src/classroom/actions/index.js
+++ b/src/classroom/actions/index.js
@@ -1,13 +1,14 @@
 import { knowledge_base, soft_skills_data, random_data } from '../../common-services/api-endpoints';
+import { RANDOM, SOFT_SKILLS } from '../../common-services/course_types';
 
 export const FETCH_COURSE = 'fetch-course';
 export const ERROR_COURSE = 'error-course';
 
 export function fetchResource(course_id, course_type) {
   let url = knowledge_base;
-  if(course_type === 'soft-skills') {
+  if(course_type === SOFT_SKILLS) {
     url = soft_skills_data;
-  } else if (course_type === 'random') {
+  } else if (course_type === RANDOM) {
     url = random_data;
   }
 

--- a/src/classroom/actions/index.js
+++ b/src/classroom/actions/index.js
@@ -1,5 +1,6 @@
 import { knowledge_base, soft_skills_data, random_data } from '../../common-services/api-endpoints';
 import { RANDOM, SOFT_SKILLS } from '../../common-services/course_types';
+import { apiCall } from '../../common-services/api-call';
 
 export const FETCH_COURSE = 'fetch-course';
 export const ERROR_COURSE = 'error-course';
@@ -14,20 +15,22 @@ export function fetchResource(course_id, course_type) {
   }
 
   return function(dispatch) {
-    fetch(`${url}${course_id}/`)
-    .then(response => {
-      response.json()
-      .then(data => {
+    apiCall(`${url}${course_id}/`, 'get')
+    .then(result => {
+      if(result.response) {
+        result.response.json()
+        .then(data => {
+          dispatch({
+            type: FETCH_COURSE,
+            payload: data
+          })
+        })
+      }
+      if(result.error) {
         dispatch({
-          type: FETCH_COURSE,
-          payload: data
-        });
-      })
-    })
-    .catch(error => {
-      dispatch({
-        type: ERROR_COURSE
-      })
+          type: ERROR_COURSE
+        })
+      }
     })
   }
 }

--- a/src/classroom/actions/index.js
+++ b/src/classroom/actions/index.js
@@ -3,6 +3,7 @@ import { RANDOM, SOFT_SKILLS } from '../../common-services/course_types';
 
 export const FETCH_COURSE = 'fetch-course';
 export const ERROR_COURSE = 'error-course';
+export const DELETE_COURSE = 'delete-course';
 
 export function fetchResource(course_id, course_type) {
   let url = knowledge_base;
@@ -28,5 +29,12 @@ export function fetchResource(course_id, course_type) {
         type: ERROR_COURSE
       })
     })
+  }
+}
+
+
+export function deleteResource() {
+  return {
+    type: DELETE_COURSE
   }
 }

--- a/src/classroom/components/embed-resource/index.js
+++ b/src/classroom/components/embed-resource/index.js
@@ -8,11 +8,20 @@ export default class Resource extends Component {
   state = { url: "" };
 
   componentDidMount() {
-    if(this.props.type === 'vimeo') {
+    let { type } = this.props;
+    this.setEmbedUrl(type);
+  }
+  componentWillReceiveProps(nextProps) {
+    let { type } = nextProps;
+    this.setEmbedUrl(type);
+  }
+
+  setEmbedUrl(type) {
+    if(type === 'vimeo') {
       let id = this.props.url.split('/').slice(-1)[0].split('?')[0];
       this.setState({ url: `https://player.vimeo.com/video/${id}`});
     }
-    else if(this.props.type === 'yt_playlist') {
+    else if(type === 'yt_playlist') {
       let id = this.props.url.split('list=')[1];
       this.setState({ url: `https://www.youtube.com/embed/videoseries?list=${id}` });
 

--- a/src/classroom/components/embed-resource/index.js
+++ b/src/classroom/components/embed-resource/index.js
@@ -8,26 +8,26 @@ export default class Resource extends Component {
   state = { url: "" };
 
   componentDidMount() {
-    let { type } = this.props;
-    this.setEmbedUrl(type);
+    let { type, url } = this.props;
+    this.setEmbedUrl(type, url);
   }
   componentWillReceiveProps(nextProps) {
-    let { type } = nextProps;
-    this.setEmbedUrl(type);
+    let { type, url } = nextProps;
+    this.setEmbedUrl(type, url);
   }
 
-  setEmbedUrl(type) {
+  setEmbedUrl(type, url) {
     if(type === 'vimeo') {
-      let id = this.props.url.split('/').slice(-1)[0].split('?')[0];
+      let id = url.split('/').slice(-1)[0].split('?')[0];
       this.setState({ url: `https://player.vimeo.com/video/${id}`});
     }
     else if(type === 'yt_playlist') {
-      let id = this.props.url.split('list=')[1];
+      let id = url.split('list=')[1];
       this.setState({ url: `https://www.youtube.com/embed/videoseries?list=${id}` });
 
     }
     else {
-      let id = this.props.url.split('v=')[1];
+      let id = url.split('v=')[1];
       this.setState({ url: `https://www.youtube.com/embed/${id}` });
     }
   }

--- a/src/classroom/components/wikipedia-search/actions/index.js
+++ b/src/classroom/components/wikipedia-search/actions/index.js
@@ -1,3 +1,5 @@
+import { apiCall } from '../../../../common-services/api-call';
+
 export const FETCH_WIKIPEDIA = 'fetch-wikipedia';
 export const EMPTY_WIKIPEDIA = 'empty-wikipedia';
 export const ERROR_WIKIPEDIA = 'error-wikipedia';
@@ -9,20 +11,22 @@ export function wikipediaSearch(term) {
     term = term.trim();
     term = term.replace(/[^a-zA-Z0-9]/g, "_");
 
-    fetch(url + term)
-    .then(response => {
-      response.json()
-      .then(data => {
-        dispatch({
-          type: FETCH_WIKIPEDIA,
-          payload: data
+    apiCall(`${url}${term}/`, 'get')
+    .then(result => {
+      if(result.response) {
+        result.response.json()
+        .then(data => {
+          dispatch({
+            type: FETCH_WIKIPEDIA,
+            payload: data
+          })
         })
-      })
-      .catch(error => {
+      }
+      if(result.error) {
         dispatch({
           type: ERROR_WIKIPEDIA
         })
-      })
+      }
     })
   }
 }

--- a/src/classroom/components/wiktionary-search/actions/index.js
+++ b/src/classroom/components/wiktionary-search/actions/index.js
@@ -1,3 +1,5 @@
+import { apiCall } from '../../../../common-services/api-call';
+
 export const FETCH_WIKTIONARY = 'fetch-wiktionary';
 export const EMPTY_WIKTIONARY = 'empty-wiktionary';
 export const ERROR_WIKTIONARY = 'error-wiktionary';
@@ -9,30 +11,32 @@ export function wiktionarySearch(term) {
     term = term.trim();
     term = term.replace(/ /g,"_");
     term = term.replace(/[^a-zA-Z0-9_]/g, "");
-    fetch(url + term)
-    .then((response) => {
-      response.json()
-      .then((data) => {
-        if(data.term_meaning) {
-          dispatch({
-            type: FETCH_WIKTIONARY,
-            payload: data
-          })
-        }
-        else {
-          dispatch({
-            type: FETCH_WIKTIONARY,
-            payload: {
-              error: 'no meaning found'
-            }
-          })
-        }
-      })
-      .catch(error => {
+    apiCall(`${url}${term}/`, 'get')
+    .then(result => {
+      if(result.response) {
+        result.response.json()
+        .then(data => {
+          if(data.term_meaning) {
+            dispatch({
+              type: FETCH_WIKTIONARY,
+              payload: data
+            })
+          }
+          else {
+            dispatch({
+              type: FETCH_WIKTIONARY,
+              payload: {
+                error: 'no meaning found'
+              }
+            })
+          }
+        })
+      }
+      if(result.error) {
         dispatch({
           type: ERROR_WIKTIONARY
         })
-      })
+      }
     })
   }
 }

--- a/src/classroom/index.js
+++ b/src/classroom/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Segment, Button, Container, Divider, Grid, Loader, Dimmer, Icon } from 'semantic-ui-react';
-import { fetchResource } from './actions';
+import { fetchResource, deleteResource } from './actions';
 import Resource from './components/embed-resource';
 import Wikipedia from './components/wikipedia-search';
 import Wiktionary from './components/wiktionary-search';
@@ -14,7 +14,7 @@ class Classroom extends Component {
 
     // push to 404, if course_type doesn't match these
     if(course_type !== KNOWLEDGE_BASE && course_type !== SOFT_SKILLS && course_type !== RANDOM) {
-      this.props.history.push('/classroom');
+      this.props.history.push('/404');
     }
     if(this.props.course.id != course_id)
       this.props.fetchResource(course_id, course_type);
@@ -25,7 +25,7 @@ class Classroom extends Component {
 
     // push to 404, if course_type doesn't match these
     if(course_type !== KNOWLEDGE_BASE && course_type !== SOFT_SKILLS && course_type !== RANDOM) {
-      this.props.history.push('/classroom');
+      this.props.history.push('/404');
     }
   }
 
@@ -34,10 +34,12 @@ class Classroom extends Component {
 
     // push to 404, if course_type doesn't match these
     if(course_type !== KNOWLEDGE_BASE && course_type !== SOFT_SKILLS && course_type !== RANDOM) {
-      this.props.history.push('/classroom');
+      this.props.history.push('/404');
     }
-    if(this.props.course.id != course_id)
+    if(this.props.match.params !== nextProps.match.params) {
+      this.props.deleteResource();
       this.props.fetchResource(course_id, course_type);
+    }
 
   }
 
@@ -130,4 +132,4 @@ function mapStateToProps({ course }) {
   return { course };
 }
 
-export default connect(mapStateToProps, { fetchResource })(Classroom);
+export default connect(mapStateToProps, { fetchResource, deleteResource })(Classroom);

--- a/src/classroom/index.js
+++ b/src/classroom/index.js
@@ -5,6 +5,7 @@ import { fetchResource } from './actions';
 import Resource from './components/embed-resource';
 import Wikipedia from './components/wikipedia-search';
 import Wiktionary from './components/wiktionary-search';
+import { KNOWLEDGE_BASE, RANDOM, SOFT_SKILLS } from '../common-services/course_types';
 
 class Classroom extends Component {
 
@@ -12,7 +13,7 @@ class Classroom extends Component {
     let { course_type, course_id } = this.props.match.params;
 
     // push to 404, if course_type doesn't match these
-    if(course_type !== 'knowledge-base' && course_type !== 'soft-skills' && course_type !== 'random') {
+    if(course_type !== KNOWLEDGE_BASE && course_type !== SOFT_SKILLS && course_type !== RANDOM) {
       this.props.history.push('/classroom');
     }
     if(this.props.course.id != course_id)
@@ -23,7 +24,7 @@ class Classroom extends Component {
     let { course_type, course_id } = this.props.match.params;
 
     // push to 404, if course_type doesn't match these
-    if(course_type !== 'knowledge-base' && course_type !== 'soft-skills' && course_type !== 'random') {
+    if(course_type !== KNOWLEDGE_BASE && course_type !== SOFT_SKILLS && course_type !== RANDOM) {
       this.props.history.push('/classroom');
     }
   }
@@ -32,7 +33,7 @@ class Classroom extends Component {
     let { course_type, course_id } = nextProps.match.params;
 
     // push to 404, if course_type doesn't match these
-    if(course_type !== 'knowledge-base' && course_type !== 'soft-skills' && course_type !== 'random') {
+    if(course_type !== KNOWLEDGE_BASE && course_type !== SOFT_SKILLS && course_type !== RANDOM) {
       this.props.history.push('/classroom');
     }
     if(this.props.course.id != course_id)

--- a/src/classroom/reducers/course-reducer.js
+++ b/src/classroom/reducers/course-reducer.js
@@ -1,4 +1,4 @@
-import { FETCH_COURSE, ERROR_COURSE } from '../actions';
+import { FETCH_COURSE, ERROR_COURSE, DELETE_COURSE } from '../actions';
 
 export default function(state = {}, action) {
 
@@ -10,6 +10,9 @@ export default function(state = {}, action) {
       return {
         error: 'An error occured'
       }
+      break;
+    case DELETE_COURSE:
+      return {};
       break;
   }
   return state;

--- a/src/common-components/course-item/components/course-labels/index.js
+++ b/src/common-components/course-item/components/course-labels/index.js
@@ -65,7 +65,7 @@ export default class CourseLabels extends Component {
             return (
               <Label
                 as={Link}
-                to={`/courses/knowledge-base/1/domain/${domain.id}/`}
+                to={`/technical/knowledge-base/domains/${domain.id}/1/`}
                 >
                 {domain.domain_name}
               </Label>
@@ -84,7 +84,7 @@ export default class CourseLabels extends Component {
             return (
               <Label
                 as={Link}
-                to={`/courses/knowledge-base/1/language/${language.id}/`}
+                to={`/technical/knowledge-base/languages/${language.id}/1/`}
                 >
                 {language.language_name}
               </Label>
@@ -104,7 +104,7 @@ export default class CourseLabels extends Component {
           return (
             <Label
               as={Link}
-              to={`/courses/soft-skills/1/soft-skill/${softskill.id}`}
+              to={`/soft-skills/${softskill.id}/1/`}
               >
               {softskill.soft_skill_category}
             </Label>

--- a/src/common-components/course-item/components/course-labels/index.js
+++ b/src/common-components/course-item/components/course-labels/index.js
@@ -65,7 +65,7 @@ export default class CourseLabels extends Component {
             return (
               <Label
                 as={Link}
-                to={`/technical/knowledge-base/domains/${domain.id}/1/`}
+                to={`/technical/knowledge-base/domains/${domain.id}/`}
                 >
                 {domain.domain_name}
               </Label>
@@ -84,7 +84,7 @@ export default class CourseLabels extends Component {
             return (
               <Label
                 as={Link}
-                to={`/technical/knowledge-base/languages/${language.id}/1/`}
+                to={`/technical/knowledge-base/languages/${language.id}/`}
                 >
                 {language.language_name}
               </Label>
@@ -104,7 +104,7 @@ export default class CourseLabels extends Component {
           return (
             <Label
               as={Link}
-              to={`/soft-skills/${softskill.id}/1/`}
+              to={`/soft-skills/${softskill.id}/`}
               >
               {softskill.soft_skill_category}
             </Label>

--- a/src/common-components/course-item/index.js
+++ b/src/common-components/course-item/index.js
@@ -48,7 +48,7 @@ export default class CourseItem extends Component {
           as={Link}
           to={{
             pathname: `/classroom/${this.props.courseType}/${this.props.course.id}`,
-            state: { fromCourses: true }
+            state: { fromCourses: this.props.fromCourses }
           }}
           >
           {this.props.course.title}

--- a/src/common-components/search-bar/actions/index.js
+++ b/src/common-components/search-bar/actions/index.js
@@ -7,6 +7,7 @@ import {
   soft_skill_api
 } from '../../../common-services/api-endpoints';
 import { KNOWLEDGE_BASE, SOFT_SKILLS, RANDOM } from '../../../common-services/course_types';
+import { SEARCH_RESULTS_PER_PAGE } from '../../../common-services/page-size';
 
 export const DELETE_SEARCH_RESULTS = 'delete-search-results';
 export const FETCH_SEARCH_RESULTS = 'fetch-search-results';
@@ -69,7 +70,7 @@ function fetchData (dispatch, api_url, category, category_id) {
   if(api_url === soft_skills_data) {
     course_type = SOFT_SKILLS;
   }
-    fetch(`${api_url}?${category}=${category_id}&page_size=`)
+    fetch(`${api_url}?${category}=${category_id}&page_size=${SEARCH_RESULTS_PER_PAGE}`)
     .then(response => {
       response.json()
       .then(data => {

--- a/src/common-components/search-bar/actions/index.js
+++ b/src/common-components/search-bar/actions/index.js
@@ -8,10 +8,12 @@ import {
 } from '../../../common-services/api-endpoints';
 import { KNOWLEDGE_BASE, SOFT_SKILLS, RANDOM } from '../../../common-services/course_types';
 import { SEARCH_RESULTS_PER_PAGE } from '../../../common-services/page-size';
+import { apiCall } from '../../../common-services/api-call';
 
 export const DELETE_SEARCH_RESULTS = 'delete-search-results';
 export const FETCH_SEARCH_RESULTS = 'fetch-search-results';
 export const NO_SEARCH_RESULTS = 'no-search-results';
+export const LOADING_SEARCH_RESULTS = 'loading-search-results';
 
 const soft_skill = 'soft_skill';
 const languages = 'languages';
@@ -70,35 +72,43 @@ function fetchData (dispatch, api_url, category, category_id) {
   if(api_url === soft_skills_data) {
     course_type = SOFT_SKILLS;
   }
-    fetch(`${api_url}?${category}=${category_id}&page_size=${SEARCH_RESULTS_PER_PAGE}`)
-    .then(response => {
-      response.json()
-      .then(data => {
-        dispatch({
-          type: FETCH_SEARCH_RESULTS,
-          payload: {
-            data,
-            course_type
-          }
+    apiCall(`${api_url}?${category}=${category_id}&page_size=${SEARCH_RESULTS_PER_PAGE}`, 'get')
+    .then(result => {
+      if(result.response) {
+        result.response.json()
+        .then(data => {
+          dispatch({
+            type: FETCH_SEARCH_RESULTS,
+            payload: {
+              data,
+              course_type
+            }
+          })
         })
-      })
+      }
     })
+
 }
 
 export function fetchMoreCourses(api_url, course_type) {
   return function(dispatch) {
-    fetch(`${api_url}`)
-    .then(response => {
-      response.json()
-      .then(data => {
-        dispatch({
-          type: FETCH_SEARCH_RESULTS,
-          payload: {
-            data,
-            course_type
-          }
+    dispatch({
+      type: LOADING_SEARCH_RESULTS
+    })
+    apiCall(api_url, 'get')
+    .then(result => {
+      if(result.response) {
+        result.response.json()
+        .then(data => {
+          dispatch({
+            type: FETCH_SEARCH_RESULTS,
+            payload: {
+              data,
+              course_type
+            }
+          })
         })
-      })
+      }
     })
   }
 }

--- a/src/common-components/search-bar/index.js
+++ b/src/common-components/search-bar/index.js
@@ -27,6 +27,15 @@ class SearchBar extends Component {
 
   renderShowMoreButton() {
     if(this.props.searchResults.next) {
+      if(this.props.searchResults.loading) {
+        return (
+          <Segment basic>
+            <Dimmer active inverted>
+              <Loader />
+            </Dimmer>
+          </Segment>
+        )
+      }
       return (
         <Button
           onClick={this.handleClick}

--- a/src/common-components/search-bar/index.js
+++ b/src/common-components/search-bar/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Form, Input, Modal, Responsive, Icon, Popup, Button, Dimmer, Loader, Segment } from 'semantic-ui-react';
+import { Form, Input, Modal, Responsive, Icon, Popup, Button, Dimmer, Loader, Segment, Container } from 'semantic-ui-react';
 import { fetchCourses, fetchMoreCourses, deleteCourses } from './actions';
 import CourseItem from '../course-item';
 
@@ -48,7 +48,7 @@ class SearchBar extends Component {
     if(this.props.searchResults.results.length) {
       return this.props.searchResults.results.map(course => {
         let { course_type } = this.props.searchResults;
-        return <CourseItem course={course} courseType={course_type} />
+        return <CourseItem course={course} courseType={course_type} fromCourses={false} />
       })
     }
     return (
@@ -88,7 +88,9 @@ class SearchBar extends Component {
             Results for "{this.state.term}":
           </Modal.Header>
           <Modal.Content>
-            {this.renderSearchResults()}
+            <Container text>
+              {this.renderSearchResults()}
+            </Container>
             <Segment basic textAlign='center'>
               {this.renderShowMoreButton()}
             </Segment>

--- a/src/common-components/search-bar/index.js
+++ b/src/common-components/search-bar/index.js
@@ -54,11 +54,9 @@ class SearchBar extends Component {
     return (
       <div>no results found</div>
     )
-
   }
 
   render() {
-    console.log(this.props.searchResults);
     return (
       <div>
         <Responsive minWidth='480'>
@@ -102,7 +100,6 @@ class SearchBar extends Component {
 }
 
 function mapStateToProps({ searchResults }) {
-  console.log(searchResults);
   return { searchResults };
 }
 

--- a/src/common-components/search-bar/reducers/search-results-reducer.js
+++ b/src/common-components/search-bar/reducers/search-results-reducer.js
@@ -1,20 +1,29 @@
-import { FETCH_SEARCH_RESULTS, DELETE_SEARCH_RESULTS, NO_SEARCH_RESULTS } from '../actions';
+import { FETCH_SEARCH_RESULTS, DELETE_SEARCH_RESULTS, NO_SEARCH_RESULTS, LOADING_SEARCH_RESULTS } from '../actions';
 
-export default function(state = { next: null, course_type: 'none', results: [] }, action) {
+export default function(state = { next: null, course_type: 'none', results: [], loading: false }, action) {
   switch (action.type) {
     case FETCH_SEARCH_RESULTS:
       let { next, results } = action.payload.data;
       let { course_type } = action.payload;
-      state = { next, course_type, results: [...state.results, ...results] }
+      state = { next, course_type, results: [...state.results, ...results], loading: false }
       return state;
       break;
 
     case DELETE_SEARCH_RESULTS:
-      return { next: null, course_type: 'none', results: [] };
+      return { next: null, course_type: 'none', results: [], loading: false };
       break;
     case NO_SEARCH_RESULTS:
-      return { next: null, course_type: 'not-found', results: [] };
+      return { next: null, course_type: 'not-found', results: [], loading: false };
       break;
+    case LOADING_SEARCH_RESULTS:
+      return {
+        next: state.next,
+        course_type: state.course_type,
+        results: state.results,
+        loading: true
+      }
+      break;
+
   }
   return state;
 }

--- a/src/common-services/api-call.js
+++ b/src/common-services/api-call.js
@@ -1,0 +1,16 @@
+
+// apiCall returns promise, if status code !=200, function return custom error object
+export function apiCall(api_url, request_type) {
+  return fetch(api_url, {
+    method: request_type
+  })
+  .then(response => {
+    if(response.status === 200)
+      return { response };
+    else
+      return { error: 'error' };
+  })
+  .catch(error => {
+    return { error };
+  })
+}

--- a/src/common-services/course_types.js
+++ b/src/common-services/course_types.js
@@ -1,3 +1,5 @@
 export const KNOWLEDGE_BASE = 'knowledge-base';
 export const SOFT_SKILLS = 'soft-skills';
 export const RANDOM = 'random';
+export const DOMAINS = 'domains';
+export const LANGUAGES = 'languages';

--- a/src/common-services/page-size.js
+++ b/src/common-services/page-size.js
@@ -1,0 +1,2 @@
+export const SEARCH_RESULTS_PER_PAGE = 3;
+export const RESULTS_PER_PAGE = 2;

--- a/src/common-services/page-size.js
+++ b/src/common-services/page-size.js
@@ -1,3 +1,3 @@
 export const SEARCH_RESULTS_PER_PAGE = 10;
-export const RESULTS_PER_PAGE = 10;
+export const RESULTS_PER_PAGE = 2;
 export const NAV_CARDS_PER_PAGE = 9;

--- a/src/common-services/page-size.js
+++ b/src/common-services/page-size.js
@@ -1,2 +1,3 @@
-export const SEARCH_RESULTS_PER_PAGE = 3;
-export const RESULTS_PER_PAGE = 2;
+export const SEARCH_RESULTS_PER_PAGE = 10;
+export const RESULTS_PER_PAGE = 10;
+export const NAV_CARDS_PER_PAGE = 9;

--- a/src/common-services/page-size.js
+++ b/src/common-services/page-size.js
@@ -1,3 +1,3 @@
 export const SEARCH_RESULTS_PER_PAGE = 10;
-export const RESULTS_PER_PAGE = 2;
+export const RESULTS_PER_PAGE = 10;
 export const NAV_CARDS_PER_PAGE = 9;

--- a/src/navigation/courses/actions/index.js
+++ b/src/navigation/courses/actions/index.js
@@ -4,6 +4,7 @@ import { DOMAINS, LANGUAGES, RANDOM, SOFT_SKILLS } from '../../../common-service
 
 export const FETCH_COURSES = 'fetch-courses';
 export const DELETE_COURSES = 'delete-courses';
+export const ERROR_COURSES = 'error-courses';
 
 
 export function fetchCourses(course_type, category_id, page_token, filters) {
@@ -41,12 +42,25 @@ export function fetchCourses(course_type, category_id, page_token, filters) {
 
     fetch(`${url}`)
     .then(response => {
-      response.json()
-      .then(data => {
+      if(response.status !== 200) {
+        // dispatching error if status code is != 200
         dispatch({
-          type: FETCH_COURSES,
-          payload: data
+          type: ERROR_COURSES
         })
+      }
+      else {
+        response.json()
+        .then(data => {
+          dispatch({
+            type: FETCH_COURSES,
+            payload: data
+          })
+        })
+      }
+      })
+    .catch(error => {
+      dispatch({
+        type: ERROR_COURSES
       })
     })
   }

--- a/src/navigation/courses/actions/index.js
+++ b/src/navigation/courses/actions/index.js
@@ -1,6 +1,7 @@
 import { knowledge_base, soft_skills_data, random_data } from '../../../common-services/api-endpoints';
 import { RESULTS_PER_PAGE } from '../../../common-services/page-size';
 import { DOMAINS, LANGUAGES, RANDOM, SOFT_SKILLS } from '../../../common-services/course_types';
+import { apiCall } from '../../../common-services/api-call';
 
 export const FETCH_COURSES = 'fetch-courses';
 export const DELETE_COURSES = 'delete-courses';
@@ -43,16 +44,10 @@ export function fetchCourses(course_type, category_id, page_token, filters) {
       url = `${url}&paid=${paid}&data_type=${data_type}&project=${project}&skill_level=${skill_level}`;
     }
 
-    fetch(`${url}`)
-    .then(response => {
-      if(response.status !== 200) {
-        // dispatching error if status code is != 200
-        dispatch({
-          type: ERROR_COURSES
-        })
-      }
-      else {
-        response.json()
+    apiCall(url, 'get')
+    .then(result => {
+      if(result.response) {
+        result.response.json()
         .then(data => {
           dispatch({
             type: FETCH_COURSES,
@@ -60,11 +55,11 @@ export function fetchCourses(course_type, category_id, page_token, filters) {
           })
         })
       }
-      })
-    .catch(error => {
-      dispatch({
-        type: ERROR_COURSES
-      })
+      if(result.error) {
+        dispatch({
+          type: ERROR_COURSES
+        })
+      }
     })
   }
 }
@@ -75,20 +70,23 @@ export function fetchMoreCourses(url) {
     dispatch({
       type: LOADING_APPEND_COURSES
     })
-    fetch(url)
-    .then(response => {
-      response.json()
-      .then(data => {
-        dispatch({
-          type: APPEND_COURSES,
-          payload: data
+
+    apiCall(url, 'get')
+    .then(result => {
+      if(result.response) {
+        result.response.json()
+        .then(data => {
+          dispatch({
+            type: APPEND_COURSES,
+            payload: data
+          })
         })
-      })
-    })
-    .catch(error => {
-      dispatch({
-        type: ERROR_APPEND_COURSES
-      })
+      }
+      if(result.error) {
+        dispatch({
+          type: ERROR_APPEND_COURSES
+        })
+      }
     })
   }
 }

--- a/src/navigation/courses/actions/index.js
+++ b/src/navigation/courses/actions/index.js
@@ -4,7 +4,7 @@ export const FETCH_COURSES = 'fetch-courses';
 export const DELETE_COURSES = 'delete-courses';
 
 
-export function fetchCourses(course_type, page_token, category, category_id, filters) {
+export function fetchCourses(course_type, category_id, page_token, filters) {
   return function(dispatch) {
     // choosing appropriate endpoint for courses
     let category_params = "";
@@ -17,11 +17,11 @@ export function fetchCourses(course_type, page_token, category, category_id, fil
     }
 
     // choosing appropriate category
-    if(category === 'domain')
+    if(course_type === 'domains')
       category_params = `&domains=${category_id}`
-    if(category === 'language')
+    if(course_type === 'languages')
       category_params = `&languages=${category_id}`
-    if(category === 'soft-skill')
+    if(course_type === 'soft-skills')
       category_params = `&soft_skill=${category_id}`
 
     // api url for fetching courses

--- a/src/navigation/courses/actions/index.js
+++ b/src/navigation/courses/actions/index.js
@@ -1,4 +1,6 @@
 import { knowledge_base, soft_skills_data, random_data } from '../../../common-services/api-endpoints';
+import { RESULTS_PER_PAGE } from '../../../common-services/page-size';
+import { DOMAINS, LANGUAGES, RANDOM, SOFT_SKILLS } from '../../../common-services/course_types';
 
 export const FETCH_COURSES = 'fetch-courses';
 export const DELETE_COURSES = 'delete-courses';
@@ -13,23 +15,23 @@ export function fetchCourses(course_type, category_id, page_token, filters) {
     // choosing appropriate endpoint for courses
     let category_params = "";
     let url = knowledge_base;
-    if(course_type === 'soft-skills') {
+    if(course_type === SOFT_SKILLS) {
       url = soft_skills_data;
     }
-    if(course_type === 'random') {
+    if(course_type === RANDOM) {
       url = random_data;
     }
 
     // choosing appropriate category
-    if(course_type === 'domains')
+    if(course_type === DOMAINS)
       category_params = `&domains=${category_id}`
-    if(course_type === 'languages')
+    if(course_type === LANGUAGES)
       category_params = `&languages=${category_id}`
-    if(course_type === 'soft-skills')
+    if(course_type === SOFT_SKILLS)
       category_params = `&soft_skill=${category_id}`
 
     // api url for fetching courses
-    url = `${url}?page=${page_token}${category_params}`;
+    url = `${url}?page_size=${RESULTS_PER_PAGE}&page=${page_token}${category_params}`;
 
     if(filters) {
       // constructing filter API URL if filters exist

--- a/src/navigation/courses/actions/index.js
+++ b/src/navigation/courses/actions/index.js
@@ -6,6 +6,10 @@ export const DELETE_COURSES = 'delete-courses';
 
 export function fetchCourses(course_type, category_id, page_token, filters) {
   return function(dispatch) {
+    if(!page_token) {
+      page_token = '1';
+    }
+
     // choosing appropriate endpoint for courses
     let category_params = "";
     let url = knowledge_base;
@@ -37,7 +41,6 @@ export function fetchCourses(course_type, category_id, page_token, filters) {
     .then(response => {
       response.json()
       .then(data => {
-        console.log(data);
         dispatch({
           type: FETCH_COURSES,
           payload: data

--- a/src/navigation/courses/actions/index.js
+++ b/src/navigation/courses/actions/index.js
@@ -5,6 +5,9 @@ import { DOMAINS, LANGUAGES, RANDOM, SOFT_SKILLS } from '../../../common-service
 export const FETCH_COURSES = 'fetch-courses';
 export const DELETE_COURSES = 'delete-courses';
 export const ERROR_COURSES = 'error-courses';
+export const APPEND_COURSES = 'append-courses';
+export const LOADING_APPEND_COURSES = 'loading-append-courses';
+export const ERROR_APPEND_COURSES = 'error-append-courses';
 
 
 export function fetchCourses(course_type, category_id, page_token, filters) {
@@ -65,6 +68,32 @@ export function fetchCourses(course_type, category_id, page_token, filters) {
     })
   }
 }
+
+export function fetchMoreCourses(url) {
+  // for fetching next page data
+  return function(dispatch) {
+    dispatch({
+      type: LOADING_APPEND_COURSES
+    })
+    fetch(url)
+    .then(response => {
+      response.json()
+      .then(data => {
+        dispatch({
+          type: APPEND_COURSES,
+          payload: data
+        })
+      })
+    })
+    .catch(error => {
+      dispatch({
+        type: ERROR_APPEND_COURSES
+      })
+    })
+  }
+}
+
+
 
 export function deleteCourses() {
   return {

--- a/src/navigation/courses/components/course-breadcrumbs/index.js
+++ b/src/navigation/courses/components/course-breadcrumbs/index.js
@@ -1,0 +1,144 @@
+import React, { Component } from 'react';
+import { Breadcrumb } from 'semantic-ui-react';
+import { Link } from 'react-router-dom';
+import { domain_api, language_api, soft_skill_api } from '../../../../common-services/api-endpoints';
+
+export default class CourseBreadcrumbs extends Component {
+  state = { categoryName: '' };
+
+  technical_breadcrumb = [
+    {
+      name: 'Technial Skills',
+      path: '/technical',
+      active: false
+    }
+  ];
+
+  random_data_breadcrumbs = [
+    ...this.technical_breadcrumb,
+    {
+      name: 'Miscellaneous',
+      path: '/technical/misc',
+      active: true
+    }
+  ]
+
+  knowledege_base_breadcrumbs = [
+    ...this.technical_breadcrumb,
+    {
+      name: 'Knowledge Base',
+      path: '/technical/knowledge-base',
+      active: false
+    }
+  ];
+
+  domain_breadcrumbs = [
+    ...this.knowledege_base_breadcrumbs,
+    {
+      name: 'Domains',
+      path: '/technical/knowledge-base/domains',
+      active: false
+    }
+  ]
+  language_breadcrumbs = [
+    ...this.knowledege_base_breadcrumbs,
+    {
+      name: 'Languages',
+      path: '/technical/knowledge-base/languages',
+      active: false
+    }
+  ]
+  soft_skills_breadcrumbs = [
+    {
+      name: 'Soft Skills',
+      path: '/soft-skills'
+    }
+  ]
+
+  componentDidMount() {
+    let { courseType, categoryId } = this.props;
+    this.fetchCourseType(courseType, categoryId);
+  }
+  componentWillReceiveProps(nextProps) {
+    let { courseType, categoryId } = nextProps;
+    if(courseType !== this.props.courseType || categoryId !== this.props.categoryId) {
+      this.fetchCourseType(courseType, categoryId);
+    }
+  }
+
+  fetchCourseType = (courseType, categoryId) => {
+    this.setState({ categoryName: ''});
+    // courseType & courseId passed down as props;
+    let url = '';
+    let name_attribute = '';
+    let categoryName = '';
+
+    if(courseType === 'domains') {
+      url = domain_api;
+      categoryName = 'domain_name';
+    }
+    if(courseType === 'languages') {
+      url = language_api;
+      categoryName = 'language_name';
+    }
+    if(courseType === 'soft-skills') {
+      url = soft_skill_api;
+      categoryName = 'soft_skill_category';
+    }
+    fetch(`${url}${categoryId}`)
+    .then(response => {
+      response.json()
+      .then(data => {
+        if(data[categoryName]) {
+          this.setState({ categoryName: data[categoryName] });
+        }
+      })
+    })
+  }
+
+
+  renderBreadcrumbs() {
+    let { courseType } = this.props;
+    let breadcrumbData = [];
+
+    if(courseType === 'domains') {
+      breadcrumbData = this.domain_breadcrumbs;
+    }
+    if(courseType === 'languages') {
+      breadcrumbData = this.language_breadcrumbs;
+    }
+    if(courseType === 'random') {
+      breadcrumbData = this.random_data_breadcrumbs;
+    }
+    if(courseType === 'soft-skills') {
+      breadcrumbData = this.soft_skills_breadcrumbs;
+    }
+
+    if(breadcrumbData.length) {
+      return breadcrumbData.map(breadcrumb => {
+        if(breadcrumb.active) {
+          return (
+            <Breadcrumb.Section active>{breadcrumb.name}</Breadcrumb.Section>
+            )
+        }
+        return [
+          <Breadcrumb.Section as={Link} to={breadcrumb.path}>{breadcrumb.name}</Breadcrumb.Section>,
+            <Breadcrumb.Divider icon='right angle' />
+          ]
+        })
+    }
+  }
+
+  render() {
+    return (
+      <div>
+        <Breadcrumb>
+          <Breadcrumb.Section as={Link} to='/'>Home</Breadcrumb.Section>
+          <Breadcrumb.Divider icon='right angle' />
+          {this.renderBreadcrumbs()}
+          <Breadcrumb.Section active>{this.state.categoryName}</Breadcrumb.Section>
+        </Breadcrumb>
+      </div>
+    )
+  }
+}

--- a/src/navigation/courses/components/course-breadcrumbs/index.js
+++ b/src/navigation/courses/components/course-breadcrumbs/index.js
@@ -3,6 +3,7 @@ import { Breadcrumb } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 import { domain_api, language_api, soft_skill_api } from '../../../../common-services/api-endpoints';
 import { DOMAINS, LANGUAGES, SOFT_SKILLS } from '../../../../common-services/course_types';
+import { apiCall } from '../../../../common-services/api-call';
 
 export default class CourseBreadcrumbs extends Component {
   state = { categoryName: '' };
@@ -86,14 +87,19 @@ export default class CourseBreadcrumbs extends Component {
       url = soft_skill_api;
       categoryName = 'soft_skill_category';
     }
-    fetch(`${url}${categoryId}`)
-    .then(response => {
-      response.json()
-      .then(data => {
-        if(data[categoryName]) {
-          this.setState({ categoryName: data[categoryName] });
-        }
-      })
+    apiCall(`${url}${categoryId}`, 'get')
+    .then(result => {
+      if(result.response) {
+        result.response.json()
+        .then(data => {
+          if(data[categoryName]) {
+            this.setState({ categoryName: data[categoryName] });
+          }
+        })
+      }
+      if(result.error) {
+        this.setState({ categoryName: '' });
+      }
     })
   }
 

--- a/src/navigation/courses/components/course-breadcrumbs/index.js
+++ b/src/navigation/courses/components/course-breadcrumbs/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Breadcrumb } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 import { domain_api, language_api, soft_skill_api } from '../../../../common-services/api-endpoints';
+import { DOMAINS, LANGUAGES, SOFT_SKILLS } from '../../../../common-services/course_types';
 
 export default class CourseBreadcrumbs extends Component {
   state = { categoryName: '' };
@@ -73,15 +74,15 @@ export default class CourseBreadcrumbs extends Component {
     let name_attribute = '';
     let categoryName = '';
 
-    if(courseType === 'domains') {
+    if(courseType === DOMAINS) {
       url = domain_api;
       categoryName = 'domain_name';
     }
-    if(courseType === 'languages') {
+    if(courseType === LANGUAGES) {
       url = language_api;
       categoryName = 'language_name';
     }
-    if(courseType === 'soft-skills') {
+    if(courseType === SOFT_SKILLS) {
       url = soft_skill_api;
       categoryName = 'soft_skill_category';
     }

--- a/src/navigation/courses/index.js
+++ b/src/navigation/courses/index.js
@@ -22,7 +22,6 @@ import CourseBreadcrumbs from './components/course-breadcrumbs';
 class Courses extends Component {
 
   componentDidMount() {
-    this.props.deleteCourses();
     let { page_token, category_id } = this.props.match.params;
     let { courseType } = this.props;
 
@@ -36,13 +35,12 @@ class Courses extends Component {
 
 
   componentDidUpdate() {
-    let { course_type } = this.props.match.params;
+    let { page_token, category_id } = this.props.match.params;
+    let { courseType } = this.props;
 
-    // push to 404, if category doesn't match 'domain' or 'language'
-    if(course_type) {
-      if(course_type !== 'knowledge-base' && course_type !== 'soft-skills' && course_type !== 'random') {
-        this.props.history.push('/courses');
-      }
+    // push to 404, if category_id and page_token is invalid
+    if(page_token < '1' || category_id < '1') {
+        this.props.history.push('/404');
     }
   }
 
@@ -71,8 +69,19 @@ class Courses extends Component {
 
   // renders fetched courses
   renderCourses() {
+    let { courseType } = this.props;
+    let course_type = '';
+    if(courseType === 'domains' || courseType === 'languages') {
+      course_type = 'knowledge-base';
+    }
+    if(courseType === 'random') {
+      course_type = 'random';
+    }
+    if(courseType === 'soft_skills') {
+      course_type = 'soft_skills';
+    }
+
     return this.props.courses.results.map((course) => {
-      let { course_type } = this.props.match.params;
       return (
         <CourseItem course={course} courseType={course_type} />
       )
@@ -83,8 +92,17 @@ class Courses extends Component {
   renderPaginationButtons() {
     let previousPageToken = "1";
     let nextPageToken = "1";
-    let category_params = "";
-    let { course_type, category, category_id } = this.props.match.params;
+    let url = "";
+    let { category_id } = this.props.match.params;
+    let { courseType } = this.props;
+
+    // setting up url
+    if(courseType === 'domains' || courseType === 'languages')
+      url = `/technical/knowledge-base/${courseType}/${category_id}`;
+    if(courseType === 'soft-skills')
+      url = `/${courseType}/${category_id}`;
+    if(courseType === 'random')
+      url = `/technical/misc`;
 
     if(this.props.courses.results.length) {
       // grabbing previous and next page number off of 'previous' and 'next' attribute
@@ -96,9 +114,6 @@ class Courses extends Component {
         if(this.props.courses.next.includes('page='))
           nextPageToken = this.props.courses.next.split(/page=(.+)/)[1].charAt(0);
       }
-      if(category && category_id) {
-        category_params = `/${category}/${category_id}`;
-      }
     }
 
 
@@ -109,7 +124,7 @@ class Courses extends Component {
           basic
           color='teal'
           as={Link}
-          to={`/courses/${course_type}/${previousPageToken}${category_params}`}
+          to={`${url}/${previousPageToken}`}
           >
           Prev
         </Button>
@@ -118,7 +133,7 @@ class Courses extends Component {
           basic
           color='teal'
           as={Link}
-          to={`/courses/${course_type}/${nextPageToken}${category_params}`}
+          to={`${url}/${nextPageToken}`}
           >
           Next
         </Button>

--- a/src/navigation/courses/index.js
+++ b/src/navigation/courses/index.js
@@ -20,17 +20,17 @@ import CourseItem from '../../common-components/course-item';
 class Courses extends Component {
 
   componentDidMount() {
+    console.log("props",this.props);
     this.props.deleteCourses();
-    let { course_type, page_token, category, category_id } = this.props.match.params;
+    let { page_token, category_id } = this.props.match.params;
+    let { courseType } = this.props;
 
     // push to 404, if category doesn't match 'domain' or 'language'
-    if(course_type) {
-      if(course_type !== 'knowledge-base' && course_type !== 'soft-skills' && course_type !== 'random') {
-        this.props.history.push('/courses');
-      }
+    if(page_token < '1' || category_id < '1') {
+        this.props.history.push('/404');
     }
     this.props.deleteCourses();
-    this.props.fetchCourses(course_type, page_token, category, category_id);
+    this.props.fetchCourses(courseType, category_id, page_token);
   }
 
 
@@ -57,7 +57,8 @@ class Courses extends Component {
 
   filterCourses = (filters) => {
     // filter courses using 'filters' props passed up by <Filters />
-    let { course_type, category, category_id } = this.props.match.params;
+    let { category_id } = this.props.match.params;
+    let { courseType } = this.props;
     // let category_params = "";
     // if(category && category_id) {
     //   category_params = `/${category}/${category_id}`
@@ -66,7 +67,7 @@ class Courses extends Component {
     // //push to first page on filter
     // this.props.history.push(`/courses/${course_type}/1${category_params}`);
     this.props.deleteCourses();
-    this.props.fetchCourses(course_type, '1', category, category_id, filters);
+    this.props.fetchCourses(courseType, category_id, 1, filters);
   }
 
 

--- a/src/navigation/courses/index.js
+++ b/src/navigation/courses/index.js
@@ -10,22 +10,23 @@ import {
   Label,
   Loader,
   Dimmer,
-  Dropdown
+  Dropdown,
+  Breadcrumb
 } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
 import { fetchCourses, deleteCourses } from './actions';
 import Filters from './components/filters';
 import CourseItem from '../../common-components/course-item';
+import CourseBreadcrumbs from './components/course-breadcrumbs';
 
 class Courses extends Component {
 
   componentDidMount() {
-    console.log("props",this.props);
     this.props.deleteCourses();
     let { page_token, category_id } = this.props.match.params;
     let { courseType } = this.props;
 
-    // push to 404, if category doesn't match 'domain' or 'language'
+    // push to 404, if category_id and page_token is invalid
     if(page_token < '1' || category_id < '1') {
         this.props.history.push('/404');
     }
@@ -46,26 +47,23 @@ class Courses extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    let { category, category_id, page_token, course_type } = nextProps.match.params;
+    let { category_id, page_token } = nextProps.match.params;
+    let { courseType } = nextProps;
+    if(page_token < '1' || category_id < '1') {
+        this.props.history.push('/404');
+    }
     if(this.props.match.params !== nextProps.match.params) {
       // fetch data only if url parameters are different
       this.props.deleteCourses();
-      this.props.fetchCourses(course_type, page_token, category, category_id);
+      this.props.fetchCourses(courseType, category_id, page_token);
     }
-
   }
 
   filterCourses = (filters) => {
     // filter courses using 'filters' props passed up by <Filters />
     let { category_id } = this.props.match.params;
     let { courseType } = this.props;
-    // let category_params = "";
-    // if(category && category_id) {
-    //   category_params = `/${category}/${category_id}`
-    // }
-    //
-    // //push to first page on filter
-    // this.props.history.push(`/courses/${course_type}/1${category_params}`);
+
     this.props.deleteCourses();
     this.props.fetchCourses(courseType, category_id, 1, filters);
   }
@@ -80,6 +78,7 @@ class Courses extends Component {
       )
     })
   }
+
 
   renderPaginationButtons() {
     let previousPageToken = "1";
@@ -145,10 +144,7 @@ class Courses extends Component {
     }
     return (
       <div>
-
-
-          {this.renderCourses()}
-
+        {this.renderCourses()}
         <Divider />
         <Segment basic textAlign='center'>
           {this.renderPaginationButtons()}
@@ -160,10 +156,12 @@ class Courses extends Component {
   render() {
     return (
       <div>
+        <Divider hidden />
+        <Container>
+          <CourseBreadcrumbs courseType={this.props.courseType} categoryId={this.props.match.params.category_id} />
+        </Container>
+        <Divider hidden />
         <Container text>
-          <Divider hidden />
-          <Header as='h1'>Courses</Header>
-          page {this.props.match.params.page_token}
           <Filters getFilters={this.filterCourses} urlParams={this.props.match.params} />
           <Divider />
           {this.renderBody()}

--- a/src/navigation/courses/index.js
+++ b/src/navigation/courses/index.js
@@ -30,7 +30,6 @@ class Courses extends Component {
     if(page_token < '1' || category_id < '1') {
         this.props.history.push('/404');
     }
-    this.props.deleteCourses();
     this.props.fetchCourses(courseType, category_id, page_token);
   }
 
@@ -46,13 +45,17 @@ class Courses extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    console.log('component received props');
+    console.log(this.props.match.params, nextProps.match.params);
     let { category_id, page_token } = nextProps.match.params;
     let { courseType } = nextProps;
     if(page_token < '1' || category_id < '1') {
         this.props.history.push('/404');
     }
-    if(this.props.match.params !== nextProps.match.params) {
-      // fetch data only if url parameters are different
+    if(this.props.match.params.category_id !== category_id
+      || this.props.courseType !== courseType
+      || this.props.match.params.page_token !== page_token) {
+      // fetch data only if url parameters and courseType props are different
       this.props.deleteCourses();
       this.props.fetchCourses(courseType, category_id, page_token);
     }
@@ -62,7 +65,6 @@ class Courses extends Component {
     // filter courses using 'filters' props passed up by <Filters />
     let { category_id } = this.props.match.params;
     let { courseType } = this.props;
-
     this.props.deleteCourses();
     this.props.fetchCourses(courseType, category_id, 1, filters);
   }

--- a/src/navigation/courses/index.js
+++ b/src/navigation/courses/index.js
@@ -18,6 +18,7 @@ import { fetchCourses, deleteCourses } from './actions';
 import Filters from './components/filters';
 import CourseItem from '../../common-components/course-item';
 import CourseBreadcrumbs from './components/course-breadcrumbs';
+import { DOMAINS, LANGUAGES, SOFT_SKILLS, KNOWLEDGE_BASE, RANDOM } from '../../common-services/course_types';
 
 class Courses extends Component {
 
@@ -71,19 +72,19 @@ class Courses extends Component {
   renderCourses() {
     let { courseType } = this.props;
     let course_type = '';
-    if(courseType === 'domains' || courseType === 'languages') {
-      course_type = 'knowledge-base';
+    if(courseType === DOMAINS || courseType === LANGUAGES) {
+      course_type = KNOWLEDGE_BASE;
     }
-    if(courseType === 'random') {
-      course_type = 'random';
+    if(courseType === RANDOM) {
+      course_type = RANDOM;
     }
-    if(courseType === 'soft_skills') {
-      course_type = 'soft_skills';
+    if(courseType === SOFT_SKILLS) {
+      course_type = SOFT_SKILLS;
     }
 
     return this.props.courses.results.map((course) => {
       return (
-        <CourseItem course={course} courseType={course_type} />
+        <CourseItem course={course} courseType={course_type} fromCourses={true} />
       )
     })
   }
@@ -97,11 +98,11 @@ class Courses extends Component {
     let { courseType } = this.props;
 
     // setting up url
-    if(courseType === 'domains' || courseType === 'languages')
+    if(courseType === DOMAINS || courseType === LANGUAGES)
       url = `/technical/knowledge-base/${courseType}/${category_id}`;
-    if(courseType === 'soft-skills')
+    if(courseType === SOFT_SKILLS)
       url = `/${courseType}/${category_id}`;
-    if(courseType === 'random')
+    if(courseType === RANDOM)
       url = `/technical/misc`;
 
     if(this.props.courses.results.length) {

--- a/src/navigation/courses/index.js
+++ b/src/navigation/courses/index.js
@@ -45,8 +45,6 @@ class Courses extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    console.log('component received props');
-    console.log(this.props.match.params, nextProps.match.params);
     let { category_id, page_token } = nextProps.match.params;
     let { courseType } = nextProps;
     if(page_token < '1' || category_id < '1') {
@@ -146,6 +144,11 @@ class Courses extends Component {
 
   // renders loader or results
   renderBody() {
+    if(this.props.courses.error) {
+      // can be pushed to any error page if response status isn't 200
+      this.props.history.push('/404');
+      return;
+    }
     if(!this.props.courses.results) {
       return (
         <Segment basic>

--- a/src/navigation/courses/reducers/courses-reducer.js
+++ b/src/navigation/courses/reducers/courses-reducer.js
@@ -1,4 +1,4 @@
-import { FETCH_COURSES, DELETE_COURSES } from '../actions';
+import { FETCH_COURSES, DELETE_COURSES, ERROR_COURSES } from '../actions';
 
 export default function(state = {}, action) {
   switch (action.type) {
@@ -7,6 +7,11 @@ export default function(state = {}, action) {
       break;
     case DELETE_COURSES:
       return {};
+      break;
+    case ERROR_COURSES:
+      return {
+        error: 'error'
+      }
       break;
   }
   return state;

--- a/src/navigation/courses/reducers/courses-reducer.js
+++ b/src/navigation/courses/reducers/courses-reducer.js
@@ -1,18 +1,58 @@
-import { FETCH_COURSES, DELETE_COURSES, ERROR_COURSES } from '../actions';
+import {
+  FETCH_COURSES,
+  DELETE_COURSES,
+  ERROR_COURSES,
+  APPEND_COURSES,
+  LOADING_APPEND_COURSES,
+  ERROR_APPEND_COURSES
+} from '../actions';
 
-export default function(state = {}, action) {
+export default function(state = { results: null, next: '', loading: false }, action) {
+  // course page renders loader if state.loaing == true
   switch (action.type) {
     case FETCH_COURSES:
-      return action.payload;
+      return {
+        results: action.payload.results,
+        next: action.payload.next,
+        loading: false
+      };
       break;
+
     case DELETE_COURSES:
       return {};
       break;
+
     case ERROR_COURSES:
       return {
         error: 'error'
       }
       break;
+
+    case LOADING_APPEND_COURSES:
+      return {
+        results: state.results,
+        next: state.next,
+        loading: true
+      };
+      break;
+
+    case APPEND_COURSES:
+      let { results, next } = state;
+      results = [...results, ...action.payload.results];
+      next = action.payload.next;
+      return {
+        results,
+        next,
+        loading: false
+      };
+      break;
+    case ERROR_APPEND_COURSES:
+      return {
+        results: state.results,
+        next: state.next,
+        loading: false
+      }
+
   }
   return state;
 }

--- a/src/navigation/domains/actions/index.js
+++ b/src/navigation/domains/actions/index.js
@@ -3,18 +3,31 @@ import { NAV_CARDS_PER_PAGE } from '../../../common-services/page-size';
 
 export const FETCH_DOMAINS = 'fetch-domains';
 export const DELETE_DOMAINS = 'delete-domains';
+export const ERROR_DOMAINS = 'error-domains';
 
 export function fetchDomains(page_token) {
   let url = `${domain_api}?page_size=${NAV_CARDS_PER_PAGE}&page=${page_token}`;
   return function(dispatch) {
     fetch(url)
     .then(response => {
-      response.json()
-      .then(data => {
+      if(response.status !== 200) {
         dispatch({
-          type: FETCH_DOMAINS,
-          payload: data
+          type: ERROR_DOMAINS
         })
+      }
+      else {
+        response.json()
+        .then(data => {
+          dispatch({
+            type: FETCH_DOMAINS,
+            payload: data
+          })
+        })
+      }
+    })
+    .catch(error => {
+      dispatch({
+        type: ERROR_DOMAINS
       })
     })
   }

--- a/src/navigation/domains/actions/index.js
+++ b/src/navigation/domains/actions/index.js
@@ -1,5 +1,6 @@
 import { domain_api } from '../../../common-services/api-endpoints';
 import { NAV_CARDS_PER_PAGE } from '../../../common-services/page-size';
+import { apiCall } from '../../../common-services/api-call';
 
 export const FETCH_DOMAINS = 'fetch-domains';
 export const DELETE_DOMAINS = 'delete-domains';
@@ -8,15 +9,10 @@ export const ERROR_DOMAINS = 'error-domains';
 export function fetchDomains(page_token) {
   let url = `${domain_api}?page_size=${NAV_CARDS_PER_PAGE}&page=${page_token}`;
   return function(dispatch) {
-    fetch(url)
-    .then(response => {
-      if(response.status !== 200) {
-        dispatch({
-          type: ERROR_DOMAINS
-        })
-      }
-      else {
-        response.json()
+    apiCall(url, 'get')
+    .then(result => {
+      if(result.response) {
+        result.response.json()
         .then(data => {
           dispatch({
             type: FETCH_DOMAINS,
@@ -24,11 +20,11 @@ export function fetchDomains(page_token) {
           })
         })
       }
-    })
-    .catch(error => {
-      dispatch({
-        type: ERROR_DOMAINS
-      })
+      if(result.error) {
+        dispatch({
+          type: ERROR_DOMAINS
+        })
+      }
     })
   }
 }

--- a/src/navigation/domains/actions/index.js
+++ b/src/navigation/domains/actions/index.js
@@ -1,9 +1,11 @@
 import { domain_api } from '../../../common-services/api-endpoints';
+import { NAV_CARDS_PER_PAGE } from '../../../common-services/page-size';
 
 export const FETCH_DOMAINS = 'fetch-domains';
+export const DELETE_DOMAINS = 'delete-domains';
 
 export function fetchDomains(page_token) {
-  let url = `${domain_api}?page_size=9&page=${page_token}`;
+  let url = `${domain_api}?page_size=${NAV_CARDS_PER_PAGE}&page=${page_token}`;
   return function(dispatch) {
     fetch(url)
     .then(response => {
@@ -15,5 +17,11 @@ export function fetchDomains(page_token) {
         })
       })
     })
+  }
+}
+
+export function deleteDomains() {
+  return {
+    type: DELETE_DOMAINS
   }
 }

--- a/src/navigation/domains/index.js
+++ b/src/navigation/domains/index.js
@@ -88,7 +88,7 @@ class Domains extends Component {
   }
 
   renderBody() {
-    if(this.props.error) {
+    if(this.props.domains.error) {
       this.props.history.push('/404');
       return;
     }

--- a/src/navigation/domains/index.js
+++ b/src/navigation/domains/index.js
@@ -72,7 +72,7 @@ class Domains extends Component {
         <Grid.Column>
           <Card
             as={Link}
-            to={`/courses/knowledge-base/1/domain/${domain.id}`}
+            to={`/technical/knowledge-base/domains/${domain.id}/1/`}
             fluid
             >
             <Image src={domain.icon} alt='' />

--- a/src/navigation/domains/index.js
+++ b/src/navigation/domains/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Container, Segment, Grid, Divider, Header, Dimmer, Loader, Menu, Card, Image } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
-import { fetchDomains } from './actions';
+import { fetchDomains, deleteDomains } from './actions';
 
 class Domains extends Component {
   state = { activePage: 1 };
@@ -18,6 +18,7 @@ class Domains extends Component {
   previousPage = () => {
     if(this.state.activePage > 1) {
       this.setState({ activePage: this.state.activePage - 1 })
+      this.props.deleteDomains();
       this.props.fetchDomains(this.state.activePage - 1);
     }
   }
@@ -25,6 +26,7 @@ class Domains extends Component {
   nextPage = () => {
     if(this.state.activePage) {
       this.setState({ activePage: this.state.activePage + 1 });
+      this.props.deleteDomains();
       this.props.fetchDomains(this.state.activePage + 1);
     }
   }
@@ -127,4 +129,4 @@ function mapStateToProps({ domains }) {
   return { domains };
 }
 
-export default connect(mapStateToProps, { fetchDomains })(Domains);
+export default connect(mapStateToProps, { fetchDomains, deleteDomains })(Domains);

--- a/src/navigation/domains/index.js
+++ b/src/navigation/domains/index.js
@@ -72,7 +72,7 @@ class Domains extends Component {
         <Grid.Column>
           <Card
             as={Link}
-            to={`/technical/knowledge-base/domains/${domain.id}/1/`}
+            to={`/technical/knowledge-base/domains/${domain.id}/`}
             fluid
             >
             <Image src={domain.icon} alt='' />

--- a/src/navigation/domains/index.js
+++ b/src/navigation/domains/index.js
@@ -88,6 +88,10 @@ class Domains extends Component {
   }
 
   renderBody() {
+    if(this.props.error) {
+      this.props.history.push('/404');
+      return;
+    }
     if(this.props.domains.count) {
       return (
         <Grid columns={3} stretched doubling centered padded relaxed='very'>

--- a/src/navigation/domains/reducers/domain-reducer.js
+++ b/src/navigation/domains/reducers/domain-reducer.js
@@ -1,9 +1,12 @@
-import { FETCH_DOMAINS } from '../actions';
+import { FETCH_DOMAINS, DELETE_DOMAINS } from '../actions';
 
 export default function(state = {}, action) {
   switch (action.type) {
     case FETCH_DOMAINS:
       return action.payload;
+      break;
+    case DELETE_DOMAINS:
+      return {};
       break;
   }
   return state;

--- a/src/navigation/domains/reducers/domain-reducer.js
+++ b/src/navigation/domains/reducers/domain-reducer.js
@@ -1,4 +1,4 @@
-import { FETCH_DOMAINS, DELETE_DOMAINS } from '../actions';
+import { FETCH_DOMAINS, DELETE_DOMAINS, ERROR_DOMAINS } from '../actions';
 
 export default function(state = {}, action) {
   switch (action.type) {
@@ -7,6 +7,11 @@ export default function(state = {}, action) {
       break;
     case DELETE_DOMAINS:
       return {};
+      break;
+    case ERROR_DOMAINS:
+      return {
+        error: 'error'
+      }
       break;
   }
   return state;

--- a/src/navigation/languages/actions/index.js
+++ b/src/navigation/languages/actions/index.js
@@ -1,9 +1,11 @@
 import { language_api } from '../../../common-services/api-endpoints';
+import { NAV_CARDS_PER_PAGE } from '../../../common-services/page-size';
 
 export const FETCH_LANGUAGES = 'fetch-languages';
+export const DELETE_LANGUAGES = 'delete-languages';
 
 export function fetchLanguages(page_token) {
-  let url = `${language_api}?page_size=9&page=${page_token}`;
+  let url = `${language_api}?page_size=${NAV_CARDS_PER_PAGE}&page=${page_token}`;
   return function(dispatch) {
     fetch(url)
     .then(response => {
@@ -15,5 +17,11 @@ export function fetchLanguages(page_token) {
         })
       })
     })
+  }
+}
+
+export function deleteLanguages() {
+  return {
+    type: DELETE_LANGUAGES
   }
 }

--- a/src/navigation/languages/actions/index.js
+++ b/src/navigation/languages/actions/index.js
@@ -3,18 +3,31 @@ import { NAV_CARDS_PER_PAGE } from '../../../common-services/page-size';
 
 export const FETCH_LANGUAGES = 'fetch-languages';
 export const DELETE_LANGUAGES = 'delete-languages';
+export const ERROR_LANGUAGES = 'error-languages';
 
 export function fetchLanguages(page_token) {
   let url = `${language_api}?page_size=${NAV_CARDS_PER_PAGE}&page=${page_token}`;
   return function(dispatch) {
     fetch(url)
     .then(response => {
-      response.json()
-      .then(data => {
+      if(response.status !== 200) {
         dispatch({
-          type: FETCH_LANGUAGES,
-          payload: data
+          type: ERROR_LANGUAGES
         })
+      }
+      else {
+        response.json()
+        .then(data => {
+          dispatch({
+            type: FETCH_LANGUAGES,
+            payload: data
+          })
+        })
+      }
+    })
+    .catch(error => {
+      dispatch({
+        type: ERROR_LANGUAGES
       })
     })
   }

--- a/src/navigation/languages/actions/index.js
+++ b/src/navigation/languages/actions/index.js
@@ -1,5 +1,6 @@
 import { language_api } from '../../../common-services/api-endpoints';
 import { NAV_CARDS_PER_PAGE } from '../../../common-services/page-size';
+import { apiCall } from '../../../common-services/api-call';
 
 export const FETCH_LANGUAGES = 'fetch-languages';
 export const DELETE_LANGUAGES = 'delete-languages';
@@ -8,15 +9,10 @@ export const ERROR_LANGUAGES = 'error-languages';
 export function fetchLanguages(page_token) {
   let url = `${language_api}?page_size=${NAV_CARDS_PER_PAGE}&page=${page_token}`;
   return function(dispatch) {
-    fetch(url)
-    .then(response => {
-      if(response.status !== 200) {
-        dispatch({
-          type: ERROR_LANGUAGES
-        })
-      }
-      else {
-        response.json()
+    apiCall(url, 'get')
+    .then(result => {
+      if(result.response) {
+        result.response.json()
         .then(data => {
           dispatch({
             type: FETCH_LANGUAGES,
@@ -24,11 +20,11 @@ export function fetchLanguages(page_token) {
           })
         })
       }
-    })
-    .catch(error => {
-      dispatch({
-        type: ERROR_LANGUAGES
-      })
+      if(result.error) {
+        dispatch({
+          type: ERROR_LANGUAGES
+        })
+      }
     })
   }
 }

--- a/src/navigation/languages/index.js
+++ b/src/navigation/languages/index.js
@@ -55,7 +55,7 @@ class Languages extends Component {
         <Grid.Column>
           <Card
             as={Link}
-            to={`/technical/knowledge-base/languages/${language.id}/1/`}
+            to={`/technical/knowledge-base/languages/${language.id}/`}
             fluid
             >
             <Image src={language.icon} alt='' />

--- a/src/navigation/languages/index.js
+++ b/src/navigation/languages/index.js
@@ -71,7 +71,7 @@ class Languages extends Component {
   }
 
   renderBody() {
-    if(this.props.error) {
+    if(this.props.languages.error) {
       this.props.history.push('/404');
       return;
     }

--- a/src/navigation/languages/index.js
+++ b/src/navigation/languages/index.js
@@ -55,7 +55,7 @@ class Languages extends Component {
         <Grid.Column>
           <Card
             as={Link}
-            to={`/courses/knowledge-base/1/language/${language.id}`}
+            to={`/technical/knowledge-base/languages/${language.id}/1/`}
             fluid
             >
             <Image src={language.icon} alt='' />

--- a/src/navigation/languages/index.js
+++ b/src/navigation/languages/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Grid, Segment, Header, Container, Divider, Loader, Dimmer, Menu, Card, Image } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
-import { fetchLanguages } from './actions';
+import { fetchLanguages, deleteLanguages } from './actions';
 
 class Languages extends Component {
   state = { activePage: 1 };
@@ -13,7 +13,8 @@ class Languages extends Component {
 
   previousPage = () => {
     if(this.state.activePage > 1) {
-      this.setState({ activePage: this.state.activePage - 1 })
+      this.setState({ activePage: this.state.activePage - 1 });
+      this.props.deleteLanguages();
       this.props.fetchLanguages(this.state.activePage - 1);
     }
   }
@@ -21,6 +22,7 @@ class Languages extends Component {
   nextPage = () => {
     if(this.state.activePage) {
       this.setState({ activePage: this.state.activePage + 1 });
+      this.props.deleteLanguages();
       this.props.fetchLanguages(this.state.activePage + 1);
     }
   }
@@ -111,4 +113,4 @@ function mapStateToProps({ languages }) {
   return { languages };
 }
 
-export default connect(mapStateToProps, { fetchLanguages })(Languages);
+export default connect(mapStateToProps, { fetchLanguages, deleteLanguages })(Languages);

--- a/src/navigation/languages/index.js
+++ b/src/navigation/languages/index.js
@@ -71,6 +71,10 @@ class Languages extends Component {
   }
 
   renderBody() {
+    if(this.props.error) {
+      this.props.history.push('/404');
+      return;
+    }
     if(this.props.languages.count) {
       return (
         <Grid columns={3} stretched doubling centered padded relaxed='very'>

--- a/src/navigation/languages/reducers/language-reducer.js
+++ b/src/navigation/languages/reducers/language-reducer.js
@@ -1,4 +1,4 @@
-import { FETCH_LANGUAGES, DELETE_LANGUAGES } from '../actions';
+import { FETCH_LANGUAGES, DELETE_LANGUAGES, ERROR_LANGUAGES } from '../actions';
 
 export default function(state = {}, action) {
   switch (action.type) {
@@ -7,6 +7,11 @@ export default function(state = {}, action) {
       break;
     case DELETE_LANGUAGES:
       return {};
+      break;
+    case ERROR_LANGUAGES:
+      return {
+        error: 'error'
+      }
       break;
   }
   return state;

--- a/src/navigation/languages/reducers/language-reducer.js
+++ b/src/navigation/languages/reducers/language-reducer.js
@@ -1,9 +1,12 @@
-import { FETCH_LANGUAGES } from '../actions';
+import { FETCH_LANGUAGES, DELETE_LANGUAGES } from '../actions';
 
 export default function(state = {}, action) {
   switch (action.type) {
     case FETCH_LANGUAGES:
       return action.payload;
+      break;
+    case DELETE_LANGUAGES:
+      return {};
       break;
   }
   return state;

--- a/src/navigation/soft-skills/actions/index.js
+++ b/src/navigation/soft-skills/actions/index.js
@@ -1,5 +1,6 @@
 import { soft_skill_api } from '../../../common-services/api-endpoints';
 import { NAV_CARDS_PER_PAGE } from '../../../common-services/page-size';
+import { apiCall } from '../../../common-services/api-call';
 
 export const FETCH_SOFT_SKILLS = 'fetch-soft-skills';
 export const DELETE_SOFT_SKILLS = 'delete-soft-skills';
@@ -8,15 +9,10 @@ export const ERROR_SOFT_SKILLS = 'error-soft-skills';
 export function fetchSoftSkills(page_token) {
   let url = `${soft_skill_api}?page_size=${NAV_CARDS_PER_PAGE}&page=${page_token}`;
   return function(dispatch) {
-    fetch(url)
-    .then(response => {
-      if(response.status !== 200) {
-        dispatch({
-          type: ERROR_SOFT_SKILLS
-        })
-      }
-      else {
-        response.json()
+    apiCall(url, 'get')
+    .then(result => {
+      if(result.response) {
+        result.response.json()
         .then(data => {
           dispatch({
             type: FETCH_SOFT_SKILLS,
@@ -24,11 +20,11 @@ export function fetchSoftSkills(page_token) {
           })
         })
       }
-    })
-    .catch(error => {
-      dispatch({
-        type: ERROR_SOFT_SKILLS
-      })
+      if(result.error) {
+        dispatch({
+          type: ERROR_SOFT_SKILLS
+        })
+      }
     })
   }
 }

--- a/src/navigation/soft-skills/actions/index.js
+++ b/src/navigation/soft-skills/actions/index.js
@@ -1,9 +1,11 @@
 import { soft_skill_api } from '../../../common-services/api-endpoints';
+import { NAV_CARDS_PER_PAGE } from '../../../common-services/page-size';
 
 export const FETCH_SOFT_SKILLS = 'fetch-soft-skills';
+export const DELETE_SOFT_SKILLS = 'delete-soft-skills';
 
 export function fetchSoftSkills(page_token) {
-  let url = `${soft_skill_api}?page_size=9&page=${page_token}`;
+  let url = `${soft_skill_api}?page_size=${NAV_CARDS_PER_PAGE}&page=${page_token}`;
   return function(dispatch) {
     fetch(url)
     .then(response => {
@@ -15,5 +17,11 @@ export function fetchSoftSkills(page_token) {
         })
       })
     })
+  }
+}
+
+export function deleteSoftSkills() {
+  return {
+    type: DELETE_SOFT_SKILLS
   }
 }

--- a/src/navigation/soft-skills/actions/index.js
+++ b/src/navigation/soft-skills/actions/index.js
@@ -3,18 +3,31 @@ import { NAV_CARDS_PER_PAGE } from '../../../common-services/page-size';
 
 export const FETCH_SOFT_SKILLS = 'fetch-soft-skills';
 export const DELETE_SOFT_SKILLS = 'delete-soft-skills';
+export const ERROR_SOFT_SKILLS = 'error-soft-skills';
 
 export function fetchSoftSkills(page_token) {
   let url = `${soft_skill_api}?page_size=${NAV_CARDS_PER_PAGE}&page=${page_token}`;
   return function(dispatch) {
     fetch(url)
     .then(response => {
-      response.json()
-      .then(data => {
+      if(response.status !== 200) {
         dispatch({
-          type: FETCH_SOFT_SKILLS,
-          payload: data
+          type: ERROR_SOFT_SKILLS
         })
+      }
+      else {
+        response.json()
+        .then(data => {
+          dispatch({
+            type: FETCH_SOFT_SKILLS,
+            payload: data
+          })
+        })
+      }
+    })
+    .catch(error => {
+      dispatch({
+        type: ERROR_SOFT_SKILLS
       })
     })
   }

--- a/src/navigation/soft-skills/index.js
+++ b/src/navigation/soft-skills/index.js
@@ -68,7 +68,7 @@ class SoftSkills extends Component {
         <Grid.Column>
           <Card
             as={Link}
-            to={`/soft-skills/${skill.id}/1/`}
+            to={`/soft-skills/${skill.id}/`}
             fluid
             >
             <Image src={skill.icon} alt='' />

--- a/src/navigation/soft-skills/index.js
+++ b/src/navigation/soft-skills/index.js
@@ -68,7 +68,7 @@ class SoftSkills extends Component {
         <Grid.Column>
           <Card
             as={Link}
-            to={`/courses/soft-skills/1/soft-skill/${skill.id}`}
+            to={`/soft-skills/${skill.id}/1/`}
             fluid
             >
             <Image src={skill.icon} alt='' />

--- a/src/navigation/soft-skills/index.js
+++ b/src/navigation/soft-skills/index.js
@@ -84,7 +84,7 @@ class SoftSkills extends Component {
   }
 
   renderBody() {
-    if(this.props.error) {
+    if(this.props.softskills.error) {
       this.props.history.push('/404');
       return;
     }

--- a/src/navigation/soft-skills/index.js
+++ b/src/navigation/soft-skills/index.js
@@ -84,6 +84,10 @@ class SoftSkills extends Component {
   }
 
   renderBody() {
+    if(this.props.error) {
+      this.props.history.push('/404');
+      return;
+    }
     if(this.props.softskills.count) {
       return (
         <Grid columns={3} stretched doubling centered padded relaxed='very'>

--- a/src/navigation/soft-skills/index.js
+++ b/src/navigation/soft-skills/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Container, Segment, Grid, Divider, Header, Loader, Dimmer, Menu, Card, Image } from 'semantic-ui-react';
 import { Link } from 'react-router-dom';
-import { fetchSoftSkills } from './actions';
+import { fetchSoftSkills, deleteSoftSkills } from './actions';
 
 class SoftSkills extends Component {
   state = { activePage: 1 };
@@ -13,7 +13,8 @@ class SoftSkills extends Component {
 
   previousPage = () => {
     if(this.state.activePage > 1) {
-      this.setState({ activePage: this.state.activePage - 1 })
+      this.setState({ activePage: this.state.activePage - 1 });
+      this.props.deleteSoftSkills();
       this.props.fetchSoftSkills(this.state.activePage - 1);
     }
   }
@@ -21,6 +22,7 @@ class SoftSkills extends Component {
   nextPage = () => {
     if(this.state.activePage) {
       this.setState({ activePage: this.state.activePage + 1 });
+      this.props.deleteSoftSkills();
       this.props.fetchSoftSkills(this.state.activePage + 1);
     }
   }
@@ -125,4 +127,4 @@ function mapStateToProps({ softskills }) {
   return { softskills };
 }
 
-export default connect(mapStateToProps, { fetchSoftSkills })(SoftSkills);
+export default connect(mapStateToProps, { fetchSoftSkills, deleteSoftSkills })(SoftSkills);

--- a/src/navigation/soft-skills/reducers/softskills-reducer.js
+++ b/src/navigation/soft-skills/reducers/softskills-reducer.js
@@ -1,4 +1,4 @@
-import { FETCH_SOFT_SKILLS } from '../actions';
+import { FETCH_SOFT_SKILLS, DELETE_SOFT_SKILLS } from '../actions';
 
 export default function(state = {}, action) {
   switch (action.type) {
@@ -6,7 +6,9 @@ export default function(state = {}, action) {
 
       return action.payload
       break;
-
+    case DELETE_SOFT_SKILLS:
+      return {};
+      break;
   }
   return state;
 }

--- a/src/navigation/soft-skills/reducers/softskills-reducer.js
+++ b/src/navigation/soft-skills/reducers/softskills-reducer.js
@@ -1,4 +1,4 @@
-import { FETCH_SOFT_SKILLS, DELETE_SOFT_SKILLS } from '../actions';
+import { FETCH_SOFT_SKILLS, DELETE_SOFT_SKILLS, ERROR_SOFT_SKILLS } from '../actions';
 
 export default function(state = {}, action) {
   switch (action.type) {
@@ -8,6 +8,11 @@ export default function(state = {}, action) {
       break;
     case DELETE_SOFT_SKILLS:
       return {};
+      break;
+    case ERROR_SOFT_SKILLS:
+      return {
+        error: 'error'
+      }
       break;
   }
   return state;

--- a/src/scenes/courses/index.js
+++ b/src/scenes/courses/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Route } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import NavBar from '../../common-components/navbar';
 import Courses from '../../navigation/courses';
 
@@ -8,7 +8,7 @@ export default class CoursesPage extends Component {
     return (
       <div>
         <NavBar />
-        <Route exact path='/courses/:course_type/:page_token/:category?/:category_id?' component={Courses} />
+        <Courses {...this.props} />
       </div>
     )
   }

--- a/src/scenes/domain-page/index.js
+++ b/src/scenes/domain-page/index.js
@@ -21,7 +21,7 @@ export default class DomainPage extends Component {
             <Breadcrumb.Section active>Domains</Breadcrumb.Section>
           </Breadcrumb>
         </Container>
-        <Domains />
+        <Domains {...this.props} />
       </div>
     )
   }

--- a/src/scenes/language-page/index.js
+++ b/src/scenes/language-page/index.js
@@ -21,7 +21,7 @@ export default class LanguagePage extends Component {
             <Breadcrumb.Section active>Languages</Breadcrumb.Section>
           </Breadcrumb>
         </Container>
-        <Languages />
+        <Languages {...this.props} />
       </div>
     )
   }

--- a/src/scenes/soft-skills-page/index.js
+++ b/src/scenes/soft-skills-page/index.js
@@ -17,7 +17,7 @@ export default class SoftSkillsPage extends Component {
             <Breadcrumb.Section active>Soft Skills</Breadcrumb.Section>
           </Breadcrumb>
         </Container>
-        <SoftSkills />
+        <SoftSkills {...this.props} />
       </div>
     )
   }

--- a/src/scenes/technical/index.js
+++ b/src/scenes/technical/index.js
@@ -42,7 +42,7 @@ export default class Technical extends Component {
                 </Grid.Column>
 
                 <Grid.Column>
-                  <Link to='/technical/misc/1/'>
+                  <Link to='/technical/misc/'>
                     <Card fluid>
                       <Card.Content>
                         <Card.Header>

--- a/src/scenes/technical/index.js
+++ b/src/scenes/technical/index.js
@@ -42,11 +42,11 @@ export default class Technical extends Component {
                 </Grid.Column>
 
                 <Grid.Column>
-                  <Link to='/courses/random/1'>
+                  <Link to='/technical/misc/1/'>
                     <Card fluid>
                       <Card.Content>
                         <Card.Header>
-                          Random
+                          Miscellaneous
                         </Card.Header>
                         <Card.Description>
                           Description


### PR DESCRIPTION
courses listing url fix
- fetched courses are now rendered on navigation routes with 
    - domain/language/soft-skill ID params 
    - ~~optional page number params~~
- UPDATE: 
 - removed page number params
  - courses page loads next page data on same page once reached to end of page 

breadcrumbs on courses page
- created CourseBreadcrumbs component,
- component logically renders breadcrumbs
- it makes an additional API call for fetching domain/language/softskill name by grabbing ID params

declared and exported constants from common-services
catched API errors and dispatched action of type ERROR
minor changes in pagination logic for course listing page

app fetches data only if next url params and current url params are different

UPDATE:
- created api-call service for making api calls
- added loader to search results modal