### PR TITLE
Search bar refactor

### DIFF
--- a/src/common-components/search-bar/actions/index.js
+++ b/src/common-components/search-bar/actions/index.js
@@ -9,6 +9,7 @@ import {
 import { KNOWLEDGE_BASE, SOFT_SKILLS, RANDOM } from '../../../common-services/course_types';
 import { SEARCH_RESULTS_PER_PAGE } from '../../../common-services/page-size';
 import { apiCall } from '../../../common-services/api-call';
+import { global_search } from '../../../common-services/api-endpoints';
 
 export const DELETE_SEARCH_RESULTS = 'delete-search-results';
 export const FETCH_SEARCH_RESULTS = 'fetch-search-results';
@@ -25,92 +26,39 @@ export function fetchCourses(term) {
   term = term.toLowerCase();
 
   return function(dispatch) {
-    let requests = [];
-    requests.push(fetch(`${domain_api}?slug=${term}`))
-    requests.push(fetch(`${language_api}?slug=${term}`))
-    requests.push(fetch(`${soft_skill_api}?slug=${term}`))
+    let url = `${global_search}?query=${term}&limit=2`;
 
-
-    Promise.all(requests)
-    .then(responses => {
-      let count = 0;
-      let fetched = false;
-      responses.map((response, index) => {
-
-        //setting up url and course_type filter for fetching courses
-        let url = knowledge_base;
-        let category = domains;
-        if(response.url.includes('api/language')) {
-          category = languages;
-        }
-        if(response.url.includes('api/soft-skills')) {
-          category = soft_skill;
-          url = soft_skills_data;
-        }
-
-        response.json()
-        .then(data => {
-          count += 1;
-          if(data.count) {
-            fetchData(dispatch, url, category, data.results[0].id);
-            fetched = true;
-            return;
-          }
-          else if(count === 3 && fetched === false) {
-            // checking if all 3 responses have been mapped && data isn't fetched
-            dispatch({
-              type: NO_SEARCH_RESULTS
-            })
-          }
+    apiCall(url, 'get')
+    .then(result => {
+      result.response.json()
+      .then(data => {
+        dispatch({
+          type: FETCH_SEARCH_RESULTS,
+          payload: data
         })
       })
     })
   }
 }
 
-function fetchData (dispatch, api_url, category, category_id) {
-  let course_type = KNOWLEDGE_BASE;
-  if(api_url === soft_skills_data) {
-    course_type = SOFT_SKILLS;
-  }
-    apiCall(`${api_url}?${category}__id=${category_id}&page_size=${SEARCH_RESULTS_PER_PAGE}`, 'get')
-    .then(result => {
-      if(result.response) {
-        result.response.json()
-        .then(data => {
-          dispatch({
-            type: FETCH_SEARCH_RESULTS,
-            payload: {
-              data,
-              course_type
-            }
-          })
-        })
-      }
-    })
-
-}
 
 export function fetchMoreCourses(api_url, course_type) {
   return function(dispatch) {
     dispatch({
       type: LOADING_SEARCH_RESULTS
     })
+
     apiCall(api_url, 'get')
     .then(result => {
-      if(result.response) {
-        result.response.json()
-        .then(data => {
-          dispatch({
-            type: FETCH_SEARCH_RESULTS,
-            payload: {
-              data,
-              course_type
-            }
-          })
+      result.response.json()
+      .then(data => {
+        dispatch({
+          type: FETCH_SEARCH_RESULTS,
+          payload: data
         })
-      }
+      })
     })
+
   }
 }
 

--- a/src/common-components/search-bar/index.js
+++ b/src/common-components/search-bar/index.js
@@ -64,8 +64,7 @@ class SearchBar extends Component {
     }
     if(this.props.searchResults.results.length) {
       return this.props.searchResults.results.map(course => {
-        let { course_type } = this.props.searchResults;
-        return <CourseItem course={course} courseType={course_type} fromCourses={false} />
+        return <CourseItem course={course.data} courseType={course.course_type} fromCourses={false} />
       })
     }
     return (

--- a/src/common-components/search-bar/index.js
+++ b/src/common-components/search-bar/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Form, Input, Modal, Responsive, Icon, Popup, Button, Dimmer, Loader, Segment, Container } from 'semantic-ui-react';
+import { Form, Input, Modal, Responsive, Icon, Popup, Button, Dimmer, Loader, Segment, Container, Label } from 'semantic-ui-react';
+import { Link } from 'react-router-dom';
 import { fetchCourses, fetchMoreCourses, deleteCourses } from './actions';
 import CourseItem from '../course-item';
 
@@ -52,6 +53,42 @@ class SearchBar extends Component {
         </Button>
       )
     }
+  }
+
+  renderTags(tags) {
+    return tags.map(tag => {
+      return (
+        <Label
+          as={Link}
+          to={tag.url}
+          >
+          {tag.name}
+        </Label>
+      )
+    })
+  }
+
+  renderTagResults(title, tags) {
+    if(tags.length) {
+      return (
+        <div>
+          {title}<br />
+          {this.renderTags(tags)}
+          <br />
+        </div>
+      )
+    }
+  }
+
+  renderAllTags() {
+    let { domain_tags, language_tags, softskill_tags } = this.props.searchResults;
+    return (
+      <div>
+        {this.renderTagResults('suggested domains:', domain_tags)}
+        {this.renderTagResults('suggested languages:', language_tags)}
+        {this.renderTagResults('suggested soft skills:', softskill_tags)}
+      </div>
+    )
   }
 
   renderSearchResults() {
@@ -108,6 +145,7 @@ class SearchBar extends Component {
           <Modal.Content scrolling>
             <Container text>
               {this.renderSearchResults()}
+              {this.renderAllTags()}
             </Container>
             <Segment basic textAlign='center'>
               {this.renderShowMoreButton()}

--- a/src/common-components/search-bar/reducers/search-results-reducer.js
+++ b/src/common-components/search-bar/reducers/search-results-reducer.js
@@ -1,19 +1,63 @@
 import { FETCH_SEARCH_RESULTS, DELETE_SEARCH_RESULTS, NO_SEARCH_RESULTS, LOADING_SEARCH_RESULTS } from '../actions';
-import { KNOWLEDGE_BASE, RANDOM, SOFT_SKILLS } from '../../../common-services/course_types';
+import { KNOWLEDGE_BASE, RANDOM, SOFT_SKILLS, DOMAINS, LANGUAGES } from '../../../common-services/course_types';
 
-export default function(state = { next: 'null', course_type: 'none', results: [], loading: false }, action) {
+export default function(state = { next: 'null', course_type: 'none', results: [], domain_tags: [], language_tags: [], softskill_tags: [], loading: false }, action) {
   switch (action.type) {
     case FETCH_SEARCH_RESULTS:
       let { next } = action.payload;
-      let results = [ ...state.results ];
+      let { results, tags, domain_tags, language_tags, softskill_tags } = state;
       let { KnowledgeBase, SoftSkillsData, RandomData } = action.payload.results;
       let resources = { KnowledgeBase, SoftSkillsData, RandomData };
+      let { Language, Domain, SoftSkills } = action.payload.results;
+      let tagObject = { Language, Domain, SoftSkills };
+
+      Object.keys(tagObject).map((key => {
+        tagObject[key].map(tag => {
+          let name = '';
+          let url = '';
+          // constructing tags (list of objects) with keys 'url' and 'name'
+          // where 'url' is redirect URL
+          if(key === 'Language') {
+            url = `/technical/languages/${tag.id}`;
+            name = tag.language_name;
+            language_tags = [
+              ...language_tags,
+              {
+                url,
+                name
+              }
+            ]
+          }
+          if(key === 'Domain') {
+            url = `/technical/domains/${tag.id}`;
+            name = tag.domain_name;
+            domain_tags = [
+              ...domain_tags,
+              {
+                url,
+                name
+              }
+            ]
+          }
+          if(key === 'SoftSkills') {
+            url = `/soft-skills/${tag.id}`;
+            name = tag.soft_skill_category;
+            softskill_tags = [
+              ...softskill_tags,
+              {
+                url,
+                name
+              }
+            ]
+          }
+        })
+      }))
 
       Object.keys(resources).map((key => {
         resources[key].map(course => {
           let course_type = '';
 
-          // constructing list of objects with keys 'course_type' and 'data'
+          // constructing results (list of objects) with keys 'course_type' and 'data'
           // where 'course_type' is used for redirect URL construction
           if(key === 'KnowledgeBase')
             course_type = KNOWLEDGE_BASE;
@@ -31,21 +75,24 @@ export default function(state = { next: 'null', course_type: 'none', results: []
           ]
         })
       }))
-      state = { next, course_type: '', results, loading: false }
+      state = { next, course_type: '', results, domain_tags, language_tags, softskill_tags, loading: false }
       return state;
       break;
 
     case DELETE_SEARCH_RESULTS:
-      return { next: null, course_type: 'none', results: [], loading: false };
+      return { next: null, course_type: 'none', results: [], domain_tags: [], language_tags: [], softskill_tags: [], loading: false };
       break;
     case NO_SEARCH_RESULTS:
-      return { next: null, course_type: 'not-found', results: [], loading: false };
+      return { next: null, course_type: 'not-found', results: [], domain_tags: [], language_tags: [], softskill_tags: [], loading: false };
       break;
     case LOADING_SEARCH_RESULTS:
       return {
         next: state.next,
         course_type: state.course_type,
         results: state.results,
+        domain_tags: state.domain_tags,
+        language_tags: state.language_tags,
+        softskill_tags: state.softskill_tags,
         loading: true
       }
       break;

--- a/src/common-components/search-bar/reducers/search-results-reducer.js
+++ b/src/common-components/search-bar/reducers/search-results-reducer.js
@@ -1,11 +1,37 @@
 import { FETCH_SEARCH_RESULTS, DELETE_SEARCH_RESULTS, NO_SEARCH_RESULTS, LOADING_SEARCH_RESULTS } from '../actions';
+import { KNOWLEDGE_BASE, RANDOM, SOFT_SKILLS } from '../../../common-services/course_types';
 
-export default function(state = { next: null, course_type: 'none', results: [], loading: false }, action) {
+export default function(state = { next: 'null', course_type: 'none', results: [], loading: false }, action) {
   switch (action.type) {
     case FETCH_SEARCH_RESULTS:
-      let { next, results } = action.payload.data;
-      let { course_type } = action.payload;
-      state = { next, course_type, results: [...state.results, ...results], loading: false }
+      let { next } = action.payload;
+      let results = [ ...state.results ];
+      let { KnowledgeBase, SoftSkillsData, RandomData } = action.payload.results;
+      let resources = { KnowledgeBase, SoftSkillsData, RandomData };
+
+      Object.keys(resources).map((key => {
+        resources[key].map(course => {
+          let course_type = '';
+
+          // constructing list of objects with keys 'course_type' and 'data'
+          // where 'course_type' is used for redirect URL construction
+          if(key === 'KnowledgeBase')
+            course_type = KNOWLEDGE_BASE;
+          if(key === 'SoftSkillsData')
+            course_type = SOFT_SKILLS;
+          if(key === 'RandomData')
+            course_type = RANDOM;
+
+          results = [
+            ...results,
+            {
+              course_type,
+              data: course
+            }
+          ]
+        })
+      }))
+      state = { next, course_type: '', results, loading: false }
       return state;
       break;
 

--- a/src/common-services/api-endpoints.js
+++ b/src/common-services/api-endpoints.js
@@ -1,13 +1,15 @@
-export const domain_api = 'https://pl-backend-development.herokuapp.com/api/domain/';
-export const language_api = 'https://pl-backend-development.herokuapp.com/api/language/';
-export const soft_skill_api = 'https://pl-backend-development.herokuapp.com/api/soft-skills/';
+export const domain_api = 'https://pl-backend-staging.herokuapp.com/api/domain/';
+export const language_api = 'https://pl-backend-staging.herokuapp.com/api/language/';
+export const soft_skill_api = 'https://pl-backend-staging.herokuapp.com/api/soft-skills/';
 
-export const knowledge_base = 'https://pl-backend-development.herokuapp.com/api/knowledge-base/';
-export const random_data = 'https://pl-backend-development.herokuapp.com/api/random-data/';
-export const soft_skills_data = 'https://pl-backend-development.herokuapp.com/api/soft-skills-data/';
+export const knowledge_base = 'https://pl-backend-staging.herokuapp.com/api/knowledge-base/';
+export const random_data = 'https://pl-backend-staging.herokuapp.com/api/random-data/';
+export const soft_skills_data = 'https://pl-backend-staging.herokuapp.com/api/soft-skills-data/';
 
-export const knowledge_base_rating = 'https://pl-backend-development.herokuapp.com/api/knowledge-base-rating/';
-export const softskills_data_rating = 'https://pl-backend-development.herokuapp.com/api/softskills-data-rating/';
-export const random_data_rating = 'https://pl-backend-development.herokuapp.com/api/random-data-rating/';
+export const knowledge_base_rating = 'https://pl-backend-staging.herokuapp.com/api/knowledge-base-rating/';
+export const softskills_data_rating = 'https://pl-backend-staging.herokuapp.com/api/softskills-data-rating/';
+export const random_data_rating = 'https://pl-backend-staging.herokuapp.com/api/random-data-rating/';
 
 export const feedback_api = 'https://pl-backend-staging.herokuapp.com/api/feedback/';
+
+export const global_search = 'http://pl-backend-staging.herokuapp.com/api/global-search/';


### PR DESCRIPTION
- SearchBar component fetches data from **global search** API endpoint
- **global search** returns 
  - domains
  - languages
  - softskills
  - knowledge base resources
  - random data resources
  - softskill data resources
- *search-results-reducer* restructures fetched data like so:
`results: [], domains: [], languages: [], softskills: []`
- where "results" is knowledge-base, random and softskill data resources combined
- *show more* button appends next page data to the above lists
- search results are structured/stored as list of objects
```
results = [
  {
    course_type: "", // used for constructing URL(to classroom)
    data: { } // resource object
  }
]
```
- similarly domains/languages/softskills are stored as list of objects with keys:
  - url (ex: '/technical/languages/')
  - name